### PR TITLE
Update workflow files to include workflow_dispatch event with default git-ref value

### DIFF
--- a/.github/workflows/code-style-check-workflow-call.yaml
+++ b/.github/workflows/code-style-check-workflow-call.yaml
@@ -1,6 +1,12 @@
 name: Code Style Check
 
 on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        required: false
+        type: string
+        default: "main"
   workflow_call:
     inputs:
       git-ref:

--- a/.github/workflows/pytest-workflow-call.yaml
+++ b/.github/workflows/pytest-workflow-call.yaml
@@ -1,6 +1,12 @@
 name: Pytest
 
 on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        required: false
+        type: string
+        default: "main"
   workflow_call:
     inputs:
       git-ref:

--- a/.github/workflows/static-type-check-workflow-call.yaml
+++ b/.github/workflows/static-type-check-workflow-call.yaml
@@ -1,6 +1,12 @@
 name: Static Type Check
 
 on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        required: false
+        type: string
+        default: "main"
   workflow_call:
     inputs:
       git-ref:

--- a/.github/workflows/validate-version-workflow-call.yaml
+++ b/.github/workflows/validate-version-workflow-call.yaml
@@ -1,6 +1,12 @@
 name: Validate Version
 
 on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        required: false
+        type: string
+        default: "main"
   workflow_call:
     inputs:
       git-ref:


### PR DESCRIPTION
This pull request updates the workflow files to include a `workflow_dispatch` event with a default `git-ref` value of "main". This allows users to manually trigger the workflows without specifying a specific git reference.