### PR TITLE
Improve the validation of probs in RunnableRandomBranch

### DIFF
--- a/runnable_family/random.py
+++ b/runnable_family/random.py
@@ -24,6 +24,8 @@ class RunnableRandomBranch(Runnable[Input, Output]):
     _generate_random_value: Callable[[], float]
     """Function to generate a random number."""
 
+    __allowed_numerical_error: float = 1e-8
+
     def __init__(
         self,
         *runnables: Runnable[Input, Output] | Callable[[Input], Output],
@@ -39,8 +41,13 @@ class RunnableRandomBranch(Runnable[Input, Output]):
         if any(map(lambda x: x < 0, probs)):
             raise ValueError(f'Probabilities must be non-negative: probs={probs}')  # noqa
         # check the sum of probabilities
-        if sum(probs) == 1.0:
+        if abs(sum(probs) - 1.0) > self.__allowed_numerical_error:
+            # NOTE: the difference is allowed to be within a small numerical error  # noqa
             raise ValueError(f'The sum of probabilities must be 1.0: sum={sum(probs)}')  # noqa
+
+        # adjust the last probability to make the sum 1.0
+        probs = list(probs)
+        probs[-1] = 1.0 - sum(probs[:-1])
 
         # set attributes
         self._runnables = [

--- a/runnable_family/random.py
+++ b/runnable_family/random.py
@@ -35,7 +35,11 @@ class RunnableRandomBranch(Runnable[Input, Output]):
             probs = [1./len(runnables)] * len(runnables)
 
         # validation
-        if sum(probs) != 1.0:
+        # check non-negative probabilities
+        if any(map(lambda x: x < 0, probs)):
+            raise ValueError(f'Probabilities must be non-negative: probs={probs}')  # noqa
+        # check the sum of probabilities
+        if sum(probs) == 1.0:
             raise ValueError(f'The sum of probabilities must be 1.0: sum={sum(probs)}')  # noqa
 
         # set attributes

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -50,6 +50,7 @@ def test_runnable_random_branch(
         ([0.25, 0.5, 0, 0.25], 0.75, 1),
         ([0.25, 0.5, 0, 0.25], 0.9, 3),
         ([0.25, 0.5, 0, 0.25], 1.0, 3),
+        ([0.25, 0.5, 0, 0.25-1e-16], 1.0, 3),  # small numerical error
     ]
 )
 def test_runnable_random_branch_with_probs(
@@ -69,13 +70,16 @@ def test_runnable_random_branch_with_probs(
 @pytest.mark.parametrize(
     'probs',
     [
-        [0.1, 0.2, 0.3],  # sum = 0.6
-        [0.1, 0.2, 0.3, 0.4, 0.5],  # sum = 1.5
+        [0.1, 0.2, 0.1, 0.2],  # sum = 0.6
+        [0.1, 0.2, 0.3, 0.5],  # sum = 1.1
     ]
 )
 def test_runnable_random_branch_with_invalid_probs(
     probs: list[float],
 ):
+    # check if the sum of probabilities is 1.0
+    assert sum(probs) != 1.0
+    # run test
     with pytest.raises(ValueError):
         RunnableRandomBranch(*runnables, probs=probs)
 

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -96,3 +96,19 @@ def test_runnable_random_branch_with_invalid_random_value(
     )
     with pytest.raises(ValueError):
         chain.invoke(0)
+
+
+@pytest.mark.parametrize(
+    'probs',
+    [
+        [-0.1, 0.2, 0.3, 0.6],
+        [0.1, -0.2, 0.3, 0.8],
+        [0.1, 0.2, -0.3, 1.0],
+    ]
+)
+def test_runnable_random_branch_with_negative_probability(probs: list[float]):  # noqa
+    # check if the sum of probabilities is 1.0
+    assert sum(probs) == 1.0
+    # run test
+    with pytest.raises(ValueError):
+        RunnableRandomBranch(*runnables, probs=probs)


### PR DESCRIPTION
This pull request adds validation for non-negative probabilities in the `RunnableRandomBranch` class. It raises a `ValueError` if any of the probabilities are negative. Additionally, it handles small numerical errors in the sum of probabilities by allowing a small numerical difference. The last probability is adjusted to make the sum exactly 1.0. This ensures that the probabilities are valid and the class functions correctly.