### PR TITLE
Update cron schedule for tests-on-schedule.yaml

### DIFF
--- a/.github/workflows/tests-on-schedule.yaml
+++ b/.github/workflows/tests-on-schedule.yaml
@@ -3,7 +3,7 @@ name: Tests On Schedule
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * 6"
+    - cron: "0 0 * * *"
 
 jobs:
   test:


### PR DESCRIPTION
This pull request updates the cron schedule for the tests-on-schedule.yaml file. The previous schedule was set to run every Saturday at midnight, but it has been changed to run every day at midnight.