### PR TITLE
Fix typo in test_basic.py

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -72,7 +72,7 @@ def test_runnable_partial_lambda(
     mock_func.assert_called_once_with(input_obj, **kwargs)
 
 
-@ pytest.mark.parametrize(
+@pytest.mark.parametrize(
     'input_obj',
     [
         0,


### PR DESCRIPTION
This pull request fixes a typo in the `test_basic.py` file. The typo was causing an error in the test case. This change ensures that the test case runs successfully without any errors.

Ref. https://github.com/hmasdev/runnable_family/actions/runs/9531895380