### PR TITLE
Update langgraph dependency to exclude version 0.1.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,11 @@ name = "runnable_family"
 description = "A python library implementing a family of Runnables in langchain"
 dynamic = ["version"]
 readme = "README.md"
-dependencies = ["grandalf >= 0.8", "langchain >= 0.1.13", "langgraph>=0.0.32"]
+dependencies = [
+    "grandalf >= 0.8",
+    "langchain >= 0.1.13",
+    "langgraph>=0.0.32,!=0.1.18",
+]
 requires-python = ">=3.10"
 authors = [{ name = "hmasdev" }]
 maintainers = [{ name = "hmasdev" }]


### PR DESCRIPTION
This pull request updates the langgraph dependency in the `runnable_family` library to exclude version 0.1.18. This is necessary to avoid compatibility issues and ensure the stability of the library.

Issue: #18