### PR TITLE
Fix git-ref input reference in version check step

### DIFF
--- a/.github/workflows/validate-version-workflow-call.yaml
+++ b/.github/workflows/validate-version-workflow-call.yaml
@@ -37,6 +37,8 @@ jobs:
       - name: Check Version
         run: |
           # Check if the tag is the same as runnable_family.__version__
-          export tag=$(echo "${{ inputs.git-ref }}" | cut -d / -f 3)
+          export tag=$(echo "$INPUTS_GIT_REF" | cut -d / -f 3)
           echo "extracted tag from git-ref: $tag"
           python -c "import os; import runnable_family; assert runnable_family.__version__ == '$tag', (runnable_family.__version__, '$tag')"
+        env:
+          INPUTS_GIT_REF: ${{ inputs.git-ref }}


### PR DESCRIPTION
Correctly reference the git-ref input to ensure accurate version checking in the workflow.