### PR TITLE
Refactor runnable_family modules for clarity and structure

### DIFF
--- a/.github/workflows/code-style-check-workflow-call.yaml
+++ b/.github/workflows/code-style-check-workflow-call.yaml
@@ -42,10 +42,3 @@ jobs:
         run: |
           flake8 runnable_family --show-source
           flake8 tests --show-source
-
-      - name: Run flake8 for langchain<0.3.0
-        run: |
-          # code stylel check for backward compatibility
-          pip install -U "langchain<0.3.0"
-          flake8 runnable_family --show-source
-          flake8 tests --show-source

--- a/.github/workflows/pytest-workflow-call.yaml
+++ b/.github/workflows/pytest-workflow-call.yaml
@@ -41,10 +41,4 @@ jobs:
       - name: Run unit tests
         run: |
           pytest -m 'not integration'
-
-      - name: Run unit tests for langchain<0.3.0
-        run: |
-          # test for backward compatibility
-          pip install -U "langchain<0.3.0"
-          pytest -m 'not integration'
           pytest --doctest-modules runnable_family

--- a/.github/workflows/pytest-workflow-call.yaml
+++ b/.github/workflows/pytest-workflow-call.yaml
@@ -47,3 +47,4 @@ jobs:
           # test for backward compatibility
           pip install -U "langchain<0.3.0"
           pytest -m 'not integration'
+          pytest --doctest-modules runnable_family

--- a/.github/workflows/static-type-check-workflow-call.yaml
+++ b/.github/workflows/static-type-check-workflow-call.yaml
@@ -42,10 +42,3 @@ jobs:
         run: |
           mypy runnable_family
           mypy tests
-
-      - name: Run mypy for langchain<0.3.0
-        run: |
-          # static type check for backward compatibility
-          pip install -U "langchain<0.3.0"
-          mypy runnable_family
-          mypy tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,7 @@ name = "runnable_family"
 description = "A python library implementing a family of Runnables in langchain"
 dynamic = ["version"]
 readme = "README.md"
-dependencies = [
-    "grandalf >= 0.8",
-    "langchain >= 0.1.13",
-    "langgraph>=0.0.32,!=0.1.18",
-]
+dependencies = ["grandalf >= 0.8", "langchain >= 0.3.0", "langgraph>=0.4.0"]
 requires-python = ">=3.10"
 authors = [{ name = "hmasdev" }]
 maintainers = [{ name = "hmasdev" }]

--- a/runnable_family/basic.py
+++ b/runnable_family/basic.py
@@ -17,6 +17,7 @@ class RunnableConstant(RunnableLambda[Input, Output]):
         >>> constant_runnable = RunnableConstant("Hello, World!")
         >>> result = constant_runnable.invoke("Any input")
         >>> print(result)  # Output: "Hello, World!"
+        Hello, World!
     """
 
     _constant: Output
@@ -45,12 +46,15 @@ class RunnableAdd(RunnableLambda[Input, Output]):
         >>> add_runnable = RunnableAdd(1)
         >>> result = add_runnable.invoke(10)
         >>> print(result)  # Output: 11
+        11
         >>> add_runnable = RunnableAdd([1], prepend=False)
         >>> result = add_runnable.invoke([10])
-        >>> print(result)  # Output: [11, 1]
+        >>> print(result)  # Output: [10, 1]
+        [10, 1]
         >>> add_runnable_right = RunnableAdd([1], prepend=True)
         >>> result = add_runnable_right.invoke([10])
         >>> print(result)  # Output: [1, 10]  # type: ignore
+        [1, 10]
     """
     _constant: Input
     _prepend: bool

--- a/runnable_family/basic.py
+++ b/runnable_family/basic.py
@@ -1,12 +1,5 @@
-from functools import partial
-import logging
-from typing import Callable, TypeVar
-from langchain_core.runnables import (
-    RunnableLambda,
-)
+from langchain_core.runnables import RunnableLambda
 from langchain_core.runnables.base import Input, Output
-
-T = TypeVar("T")
 
 
 class RunnableConstant(RunnableLambda[Input, Output]):
@@ -47,44 +40,3 @@ class RunnableAdd(RunnableLambda[Input, Output]):
             return x + self._constant  # type: ignore
         else:
             return self._constant + x  # type: ignore
-
-
-class RunnablePartialLambda(RunnableLambda[Input, Output]):
-    '''RunnableLambda with keyword arguments bound.
-
-    Args:
-        func: Either sync or async callable
-        **kwargs: Keyword arguments to bound to the function.
-    '''
-
-    def __init__(self, func: Callable[[Input], Output], **kwargs):
-        super().__init__(partial(func, **kwargs))
-
-
-class RunnableLog(RunnableLambda[T, T]):
-    '''Runnable that logs the input before returning it.
-
-    Args:
-        output_func: Function to call with the input.
-            Default is logging.info.
-    '''
-
-    def __init__(
-        self,
-        output_func: Callable[[T], None] = logging.info,
-        **kwargs,
-    ):
-        func = partial(
-            self.__identity_with_output,
-            output_func=output_func
-        )
-        super().__init__(func, **kwargs)
-
-    @staticmethod
-    def __identity_with_output(
-        x: T,
-        output_func: Callable[[T,], None] | None = None,
-    ) -> T:
-        if output_func:
-            output_func(x)
-        return x

--- a/runnable_family/basic.py
+++ b/runnable_family/basic.py
@@ -3,40 +3,73 @@ from langchain_core.runnables.base import Input, Output
 
 
 class RunnableConstant(RunnableLambda[Input, Output]):
-    '''Runnable that always returns a constant output.
-    '''
+    """Runnable that always returns a constant value.
+
+    Args:
+        constant: The constant value to return, regardless of the input.
+            The input is ignored.
+
+    Attributes:
+        _constant (Output): The constant value to return.
+
+    Example:
+        >>> from runnable_family.basic import RunnableConstant
+        >>> constant_runnable = RunnableConstant("Hello, World!")
+        >>> result = constant_runnable.invoke("Any input")
+        >>> print(result)  # Output: "Hello, World!"
+    """
+
+    _constant: Output
 
     def __init__(self, constant: Output, *args, **kwargs):
         super().__init__(lambda _: constant, *args, **kwargs)
 
 
 class RunnableAdd(RunnableLambda[Input, Output]):
-    '''Runnable that adds a constant to the input.
+    """Runnable that adds a constant to the input.
 
     Args:
-        constant: Constant to be added.
-        left: If True, the constant is added to the left side.
-            Otherwise, it is added to the right side.
-            That is, x + constant if left is True, and constant + x otherwise.
-    '''
+        constant: The constant value to add to the input.
+            The input type must support addition operation.
+        prepend: If True, adds the constant to the left side of the input.
+            If False, adds the constant to the right side of the input.
+            That is, `constant + input` if `prepend=True` and
+            `input + constant` if `prepend=False`.
+
+    Attributes:
+        _constant (Input): The constant value to add.
+        _prepend (bool): Whether to prepend the constant to the input.
+
+    Example:
+        >>> from runnable_family.basic import RunnableAdd
+        >>> add_runnable = RunnableAdd(1)
+        >>> result = add_runnable.invoke(10)
+        >>> print(result)  # Output: 11
+        >>> add_runnable = RunnableAdd([1], prepend=False)
+        >>> result = add_runnable.invoke([10])
+        >>> print(result)  # Output: [11, 1]
+        >>> add_runnable_right = RunnableAdd([1], prepend=True)
+        >>> result = add_runnable_right.invoke([10])
+        >>> print(result)  # Output: [1, 10]  # type: ignore
+    """
     _constant: Input
-    _left: bool
+    _prepend: bool
 
     def __init__(
         self,
         constant: Input,
-        left: bool = True,
+        prepend: bool = False,
         *args,
         **kwargs,
     ):
         self._constant = constant
-        self._left = left
+        self._prepend = prepend
         super().__init__(self._add, *args, **kwargs)
 
     def _add(self, x: Input) -> Output:
         if not hasattr(x, "__add__"):
             raise TypeError(f"Cannot add {x} and {self._constant}")
-        if self._left:
-            return x + self._constant  # type: ignore
-        else:
+        if self._prepend:
             return self._constant + x  # type: ignore
+        else:
+            return x + self._constant  # type: ignore

--- a/runnable_family/gacha.py
+++ b/runnable_family/gacha.py
@@ -5,7 +5,6 @@ from langchain_core.runnables import (
     RunnableSequence,
 )
 from langchain_core.runnables.base import Input, Output
-from typing import Any
 
 
 class RunnableGacha(RunnableSequence[Input, list[Output]]):

--- a/runnable_family/gacha.py
+++ b/runnable_family/gacha.py
@@ -2,48 +2,48 @@ from langchain_core.runnables import (
     Runnable,
     RunnableLambda,
     RunnableParallel,
+    RunnableSequence,
 )
 from langchain_core.runnables.base import Input, Output
 from typing import Any
 
 
-class RunnableGacha(Runnable[Input, Output]):
-    ''' A simple implementation of Gacha Chain
+class RunnableGacha(RunnableSequence[Input, list[Output]]):
+    """Runnable that runs the same runnable multiple times in parallel.
+    This is useful for scenarios where you want to gather multiple outputs
+    from the same runnable, such as in a gacha system where you want to
+    simulate drawing multiple items or results.
 
-    Here is "Gacha" means to run the same runnable multiple times in parallel
-    '''
+    Here is "Gacha" means "lottery" or "draw" in Japanese, and it is often used
+    in the context of games or applications where users can draw random items
+    or characters.
 
-    _chain: Runnable[Input, Output]
+    Args:
+        runnable: The runnable to run multiple times.
+        n: The number of times to run the runnable in parallel.
+            Default is 10.
+    Attributes:
+        _chain (Runnable[Input, Output]): The chain of runnables that runs
+            the same runnable `n` times in parallel and collects the results
+            into a list.
+    Example:
+        >>> from runnable_family.gacha import RunnableGacha
+        >>> from langchain_core.runnables import RunnableLambda
+        >>> def my_runnable(x):
+        ...     return x * 2
+        >>> gacha_runnable = RunnableGacha(RunnableLambda(my_runnable), n=5)
+        >>> results = gacha_runnable.invoke(10)
+        >>> print(results)  # Output: [20, 20, 20, 20, 20]
+        >>> # This will run `my_runnable` 5 times in parallel with input 10
+    """
 
     def __init__(
         self,
         runnable: Runnable[Input, Output],
         n: int = 10,
     ):
-        self._chain = (
-            RunnableParallel(**{str(i): runnable for i in range(n)})  # type: ignore  # noqa
-            | RunnableLambda(lambda dic: dic.values())
-            | RunnableLambda(list)
-        ).with_types(
-            input_type=runnable.InputType,
-            output_type=list[runnable.OutputType],  # type: ignore
+        super().__init__(
+            RunnableParallel(**{str(i): runnable for i in range(n)}).with_types(input_type=runnable.InputType),  # type: ignore # noqa
+            RunnableLambda(lambda dic: dic.values()),
+            RunnableLambda(list).with_types(output_type=list[runnable.OutputType]),  # type: ignore # noqa
         )
-
-    def invoke(self, *args, **kwargs) -> Output:
-        return self._chain.invoke(*args, **kwargs)
-
-    def __getattribute__(self, name: str) -> Any:
-        if name in ["_chain", "invoke"]:
-            return super().__getattribute__(name)
-        try:
-            return getattr(self._chain, name)
-        except AttributeError:
-            return super().__getattribute__(name)
-
-    @property
-    def InputType(self) -> type[Input]:
-        return self._chain.InputType
-
-    @property
-    def OutputType(self) -> type[Output]:
-        return self._chain.OutputType

--- a/runnable_family/gacha.py
+++ b/runnable_family/gacha.py
@@ -34,6 +34,7 @@ class RunnableGacha(RunnableSequence[Input, list[Output]]):
         >>> gacha_runnable = RunnableGacha(RunnableLambda(my_runnable), n=5)
         >>> results = gacha_runnable.invoke(10)
         >>> print(results)  # Output: [20, 20, 20, 20, 20]
+        [20, 20, 20, 20, 20]
         >>> # This will run `my_runnable` 5 times in parallel with input 10
     """
 

--- a/runnable_family/lambda_family.py
+++ b/runnable_family/lambda_family.py
@@ -1,52 +1,7 @@
 from functools import partial
-import logging
-from typing import Callable, TypeVar
-from langchain_core.runnables import (
-    RunnableLambda,
-)
+from typing import Callable
+from langchain_core.runnables import RunnableLambda
 from langchain_core.runnables.base import Input, Output
-
-T = TypeVar("T")
-
-
-class RunnableConstant(RunnableLambda[Input, Output]):
-    '''Runnable that always returns a constant output.
-    '''
-
-    def __init__(self, constant: Output, *args, **kwargs):
-        super().__init__(lambda _: constant, *args, **kwargs)
-
-
-class RunnableAdd(RunnableLambda[Input, Output]):
-    '''Runnable that adds a constant to the input.
-
-    Args:
-        constant: Constant to be added.
-        left: If True, the constant is added to the left side.
-            Otherwise, it is added to the right side.
-            That is, x + constant if left is True, and constant + x otherwise.
-    '''
-    _constant: Input
-    _left: bool
-
-    def __init__(
-        self,
-        constant: Input,
-        left: bool = True,
-        *args,
-        **kwargs,
-    ):
-        self._constant = constant
-        self._left = left
-        super().__init__(self._add, *args, **kwargs)
-
-    def _add(self, x: Input) -> Output:
-        if not hasattr(x, "__add__"):
-            raise TypeError(f"Cannot add {x} and {self._constant}")
-        if self._left:
-            return x + self._constant  # type: ignore
-        else:
-            return self._constant + x  # type: ignore
 
 
 class RunnablePartialLambda(RunnableLambda[Input, Output]):
@@ -59,32 +14,3 @@ class RunnablePartialLambda(RunnableLambda[Input, Output]):
 
     def __init__(self, func: Callable[[Input], Output], **kwargs):
         super().__init__(partial(func, **kwargs))
-
-
-class RunnableLog(RunnableLambda[T, T]):
-    '''Runnable that logs the input before returning it.
-
-    Args:
-        output_func: Function to call with the input.
-            Default is logging.info.
-    '''
-
-    def __init__(
-        self,
-        output_func: Callable[[T], None] = logging.info,
-        **kwargs,
-    ):
-        func = partial(
-            self.__identity_with_output,
-            output_func=output_func
-        )
-        super().__init__(func, **kwargs)
-
-    @staticmethod
-    def __identity_with_output(
-        x: T,
-        output_func: Callable[[T,], None] | None = None,
-    ) -> T:
-        if output_func:
-            output_func(x)
-        return x

--- a/runnable_family/lambda_family.py
+++ b/runnable_family/lambda_family.py
@@ -5,11 +5,22 @@ from langchain_core.runnables.base import Input, Output
 
 
 class RunnablePartialLambda(RunnableLambda[Input, Output]):
-    '''RunnableLambda with keyword arguments bound.
+    '''Runnable that binds keyword arguments to a function.
 
     Args:
-        func: Either sync or async callable
-        **kwargs: Keyword arguments to bound to the function.
+        func: The function to bind the keyword arguments to.
+        **kwargs: Keyword arguments to bind to the function.
+
+    Example:
+        >>> from runnable_family.lambda_family import RunnablePartialLambda
+        >>> def my_func(x, a, b):
+        ...     return x + a + b
+        >>> partial_lambda = RunnablePartialLambda(my_func, a='A', b='B')
+        >>> result = partial_lambda.invoke('x')
+        >>> print(result)  # Output: 'xAB'
+
+    Note:
+        This class is equivalent to `RunnableLambda(partial(func, **kwargs))`.
     '''
 
     def __init__(self, func: Callable[[Input], Output], **kwargs):

--- a/runnable_family/lambda_family.py
+++ b/runnable_family/lambda_family.py
@@ -18,6 +18,7 @@ class RunnablePartialLambda(RunnableLambda[Input, Output]):
         >>> partial_lambda = RunnablePartialLambda(my_func, a='A', b='B')
         >>> result = partial_lambda.invoke('x')
         >>> print(result)  # Output: 'xAB'
+        xAB
 
     Note:
         This class is equivalent to `RunnableLambda(partial(func, **kwargs))`.

--- a/runnable_family/lambda_family.py
+++ b/runnable_family/lambda_family.py
@@ -1,0 +1,90 @@
+from functools import partial
+import logging
+from typing import Callable, TypeVar
+from langchain_core.runnables import (
+    RunnableLambda,
+)
+from langchain_core.runnables.base import Input, Output
+
+T = TypeVar("T")
+
+
+class RunnableConstant(RunnableLambda[Input, Output]):
+    '''Runnable that always returns a constant output.
+    '''
+
+    def __init__(self, constant: Output, *args, **kwargs):
+        super().__init__(lambda _: constant, *args, **kwargs)
+
+
+class RunnableAdd(RunnableLambda[Input, Output]):
+    '''Runnable that adds a constant to the input.
+
+    Args:
+        constant: Constant to be added.
+        left: If True, the constant is added to the left side.
+            Otherwise, it is added to the right side.
+            That is, x + constant if left is True, and constant + x otherwise.
+    '''
+    _constant: Input
+    _left: bool
+
+    def __init__(
+        self,
+        constant: Input,
+        left: bool = True,
+        *args,
+        **kwargs,
+    ):
+        self._constant = constant
+        self._left = left
+        super().__init__(self._add, *args, **kwargs)
+
+    def _add(self, x: Input) -> Output:
+        if not hasattr(x, "__add__"):
+            raise TypeError(f"Cannot add {x} and {self._constant}")
+        if self._left:
+            return x + self._constant  # type: ignore
+        else:
+            return self._constant + x  # type: ignore
+
+
+class RunnablePartialLambda(RunnableLambda[Input, Output]):
+    '''RunnableLambda with keyword arguments bound.
+
+    Args:
+        func: Either sync or async callable
+        **kwargs: Keyword arguments to bound to the function.
+    '''
+
+    def __init__(self, func: Callable[[Input], Output], **kwargs):
+        super().__init__(partial(func, **kwargs))
+
+
+class RunnableLog(RunnableLambda[T, T]):
+    '''Runnable that logs the input before returning it.
+
+    Args:
+        output_func: Function to call with the input.
+            Default is logging.info.
+    '''
+
+    def __init__(
+        self,
+        output_func: Callable[[T], None] = logging.info,
+        **kwargs,
+    ):
+        func = partial(
+            self.__identity_with_output,
+            output_func=output_func
+        )
+        super().__init__(func, **kwargs)
+
+    @staticmethod
+    def __identity_with_output(
+        x: T,
+        output_func: Callable[[T,], None] | None = None,
+    ) -> T:
+        if output_func:
+            output_func(x)
+        return x

--- a/runnable_family/loopback.py
+++ b/runnable_family/loopback.py
@@ -21,8 +21,46 @@ else:
 
 
 class RunnableLoopback(Runnable[Input, Output]):
-    '''Runnable that loops back the output to the input.
-    '''
+    """Runnable that loops back the output to the input until a condition is met.
+    This runnable is useful for scenarios where you want to repeatedly process
+    the output of a runnable until a certain condition is satisfied, such as
+    in iterative algorithms or feedback loops.
+
+    Args:
+        runnable (Runnable[Input, Output]): The runnable to be looped back.
+            This is the main processing unit that will be executed repeatedly.
+        condition (Runnable[Output, bool] | Callable[[Output], bool]): A
+            condition that determines whether to continue looping back or not.
+            If a callable is provided, it will be wrapped in a RunnableLambda.
+        loopback (Runnable[Output, Input]): A runnable that takes the output
+            of the main runnable and transforms it back into the input format
+            for the next iteration.
+
+    Attributes:
+        _graph (CompiledGraph): Compiled graph of the runnable.
+        _runnable (Runnable[Input, Output]): The main runnable to be looped back.
+        _condition (Runnable[Output, bool]): Condition to determine if looping continues.
+        _loopback (Runnable[Output, Input]): Runnable to transform output back to input.
+
+    Example:
+        >>> from runnable_family.loopback import RunnableLoopback
+        >>> from langchain_core.runnables import RunnableLambda
+        >>> def my_runnable(x):
+        ...     return x + 1
+        >>> def my_condition(output):
+        ...     return output < 5
+        >>> def my_loopback(output):
+        ...     return output * 2
+        >>> loopback_runnable = RunnableLoopback(
+        ...    runnable=RunnableLambda(my_runnable),
+        ...    condition=RunnableLambda(my_condition),
+        ...    loopback=RunnableLambda(my_loopback)
+        ... )
+        >>> result = loopback_runnable.invoke(0)
+        >>> print(result)  # Output: 7
+        7
+        >>> # 0 -(my_runnable)-> 1 -(my_loopback)-> 2 -(my_runnable)-> 3 -(my_loopback)-> 6 -(my_runnable)-> 7
+    """  # noqa
 
     _graph: CompiledGraph
     '''Compiled graph of the runnable.'''

--- a/runnable_family/print_family.py
+++ b/runnable_family/print_family.py
@@ -20,6 +20,7 @@ class RunnableLog(RunnableLambda[T, T]):
         >>> result = log_runnable.invoke("Hello, World!")
         >>> # This will log "Hello, World!" using logging.info
         >>> print(result)  # Output: "Hello, World!"
+        Hello, World!
     """
 
     def __init__(

--- a/runnable_family/print_family.py
+++ b/runnable_family/print_family.py
@@ -1,64 +1,9 @@
 from functools import partial
 import logging
 from typing import Callable, TypeVar
-from langchain_core.runnables import (
-    RunnableLambda,
-)
-from langchain_core.runnables.base import Input, Output
+from langchain_core.runnables import RunnableLambda
 
 T = TypeVar("T")
-
-
-class RunnableConstant(RunnableLambda[Input, Output]):
-    '''Runnable that always returns a constant output.
-    '''
-
-    def __init__(self, constant: Output, *args, **kwargs):
-        super().__init__(lambda _: constant, *args, **kwargs)
-
-
-class RunnableAdd(RunnableLambda[Input, Output]):
-    '''Runnable that adds a constant to the input.
-
-    Args:
-        constant: Constant to be added.
-        left: If True, the constant is added to the left side.
-            Otherwise, it is added to the right side.
-            That is, x + constant if left is True, and constant + x otherwise.
-    '''
-    _constant: Input
-    _left: bool
-
-    def __init__(
-        self,
-        constant: Input,
-        left: bool = True,
-        *args,
-        **kwargs,
-    ):
-        self._constant = constant
-        self._left = left
-        super().__init__(self._add, *args, **kwargs)
-
-    def _add(self, x: Input) -> Output:
-        if not hasattr(x, "__add__"):
-            raise TypeError(f"Cannot add {x} and {self._constant}")
-        if self._left:
-            return x + self._constant  # type: ignore
-        else:
-            return self._constant + x  # type: ignore
-
-
-class RunnablePartialLambda(RunnableLambda[Input, Output]):
-    '''RunnableLambda with keyword arguments bound.
-
-    Args:
-        func: Either sync or async callable
-        **kwargs: Keyword arguments to bound to the function.
-    '''
-
-    def __init__(self, func: Callable[[Input], Output], **kwargs):
-        super().__init__(partial(func, **kwargs))
 
 
 class RunnableLog(RunnableLambda[T, T]):

--- a/runnable_family/print_family.py
+++ b/runnable_family/print_family.py
@@ -7,12 +7,20 @@ T = TypeVar("T")
 
 
 class RunnableLog(RunnableLambda[T, T]):
-    '''Runnable that logs the input before returning it.
+    """Runnable that logs the input and returns it unchanged.
 
     Args:
-        output_func: Function to call with the input.
-            Default is logging.info.
-    '''
+        output_func: A callable that takes the input and logs it.
+            Defaults to `logging.info`.
+        **kwargs: Additional keyword arguments to pass to the base class.
+
+    Example:
+        >>> from runnable_family.print_family import RunnableLog
+        >>> log_runnable = RunnableLog()
+        >>> result = log_runnable.invoke("Hello, World!")
+        >>> # This will log "Hello, World!" using logging.info
+        >>> print(result)  # Output: "Hello, World!"
+    """
 
     def __init__(
         self,
@@ -20,13 +28,13 @@ class RunnableLog(RunnableLambda[T, T]):
         **kwargs,
     ):
         func = partial(
-            self.__identity_with_output,
+            self._identity_with_output,
             output_func=output_func
         )
         super().__init__(func, **kwargs)
 
     @staticmethod
-    def __identity_with_output(
+    def _identity_with_output(
         x: T,
         output_func: Callable[[T,], None] | None = None,
     ) -> T:

--- a/runnable_family/print_family.py
+++ b/runnable_family/print_family.py
@@ -1,0 +1,90 @@
+from functools import partial
+import logging
+from typing import Callable, TypeVar
+from langchain_core.runnables import (
+    RunnableLambda,
+)
+from langchain_core.runnables.base import Input, Output
+
+T = TypeVar("T")
+
+
+class RunnableConstant(RunnableLambda[Input, Output]):
+    '''Runnable that always returns a constant output.
+    '''
+
+    def __init__(self, constant: Output, *args, **kwargs):
+        super().__init__(lambda _: constant, *args, **kwargs)
+
+
+class RunnableAdd(RunnableLambda[Input, Output]):
+    '''Runnable that adds a constant to the input.
+
+    Args:
+        constant: Constant to be added.
+        left: If True, the constant is added to the left side.
+            Otherwise, it is added to the right side.
+            That is, x + constant if left is True, and constant + x otherwise.
+    '''
+    _constant: Input
+    _left: bool
+
+    def __init__(
+        self,
+        constant: Input,
+        left: bool = True,
+        *args,
+        **kwargs,
+    ):
+        self._constant = constant
+        self._left = left
+        super().__init__(self._add, *args, **kwargs)
+
+    def _add(self, x: Input) -> Output:
+        if not hasattr(x, "__add__"):
+            raise TypeError(f"Cannot add {x} and {self._constant}")
+        if self._left:
+            return x + self._constant  # type: ignore
+        else:
+            return self._constant + x  # type: ignore
+
+
+class RunnablePartialLambda(RunnableLambda[Input, Output]):
+    '''RunnableLambda with keyword arguments bound.
+
+    Args:
+        func: Either sync or async callable
+        **kwargs: Keyword arguments to bound to the function.
+    '''
+
+    def __init__(self, func: Callable[[Input], Output], **kwargs):
+        super().__init__(partial(func, **kwargs))
+
+
+class RunnableLog(RunnableLambda[T, T]):
+    '''Runnable that logs the input before returning it.
+
+    Args:
+        output_func: Function to call with the input.
+            Default is logging.info.
+    '''
+
+    def __init__(
+        self,
+        output_func: Callable[[T], None] = logging.info,
+        **kwargs,
+    ):
+        func = partial(
+            self.__identity_with_output,
+            output_func=output_func
+        )
+        super().__init__(func, **kwargs)
+
+    @staticmethod
+    def __identity_with_output(
+        x: T,
+        output_func: Callable[[T,], None] | None = None,
+    ) -> T:
+        if output_func:
+            output_func(x)
+        return x

--- a/runnable_family/random.py
+++ b/runnable_family/random.py
@@ -117,10 +117,10 @@ class RunnableRandomBranch(RunnableSequence[Input, Output]):
                 *[
                     (
                         RunnablePick("rv")
-                        | RunnableLambda(partial(self._a_is_ge_0_le_b, b=thresh)),
+                        | RunnableLambda(partial(self._a_is_ge_0_le_b, b=thresh)),  # noqa
                         RunnablePick("x") | runnable,
                     )
-                    for runnable, thresh in zip(self._runnables, self._cum_probs)
+                    for runnable, thresh in zip(self._runnables, self._cum_probs)  # noqa
                 ],
                 (
                     RunnablePick("rv")

--- a/runnable_family/random.py
+++ b/runnable_family/random.py
@@ -1,19 +1,66 @@
+from functools import partial
 from itertools import accumulate
 import operator
 import random
 from typing import Callable, Iterable
-from langchain_core.runnables import Runnable, RunnableLambda
+from langchain_core.runnables import (
+    Runnable,
+    RunnableBranch,
+    RunnableLambda,
+    RunnableMap,
+    RunnablePassthrough,
+    RunnablePick,
+    RunnableSequence,
+)
 from langchain_core.runnables.base import Input, Output
 
 
-class RunnableRandomBranch(Runnable[Input, Output]):
-    '''Runnable that branches the input to multiple runnables based on random probabilities.
+class RunnableRandomBranch(RunnableSequence[Input, Output]):
+    """Runnable that branches to one of the runnables based on given probabilities.
+    This runnable randomly selects one of the provided runnables based on the specified probabilities.
+    It is useful for scenarios where you want to randomly choose a runnable to execute,
+    such as in a game or simulation where different outcomes are possible based on probabilities.
 
     Args:
-        *runnables: runnables to be branched.
-        probs: Probabilities of the runnables. If None, equal probabilities are assigned.
-        generate_random_value: Function to generate a random number. Default is random.random.
-    '''  # noqa
+        *runnables: A variable number of runnables or callables that take an input
+            and return an output. These are the runnables to be branched.
+        probs: An iterable of probabilities corresponding to each runnable.
+            If not provided, equal probabilities are assigned to each runnable.
+        generate_random_value: A callable that generates a random value between 0 and 1.
+            Defaults to `random.random`.
+
+    Attributes:
+        _runnables (Iterable[Runnable[Input, Output]]): List of runnables to be branched.
+        _cum_probs (list[float]): Cumulative probabilities of the runnables.
+        _generate_random_value (Callable[[], float]): Function to generate a random number.
+        _allowed_numerical_error: float = 1e-8
+
+    Example:
+        >>> from itertools import cycle
+        >>> from runnable_family.random import RunnableRandomBranch
+        >>> from langchain_core.runnables import RunnableLambda
+        >>> def runnable_a(x):
+        ...     return f"A: {x}"
+        >>> def runnable_b(x):
+        ...     return f"B: {x}"
+        >>> def runnable_c(x):
+        ...     return f"C: {x}"
+        >>> branch = RunnableRandomBranch(
+        ...     RunnableLambda(runnable_a),
+        ...     RunnableLambda(runnable_b),
+        ...     RunnableLambda(runnable_c),
+        ...     generate_random_value=cycle([0.5, 0.2, 0.4, 0.8, 0.9, 0.01,]).__next__,
+        ... )
+        >>> result = branch.invoke("test input")
+        >>> print(result)
+        B: test input
+        >>> result = branch.invoke("another input")
+        >>> print(result)
+        A: another input
+        >>> result = branch.invoke("yet another input")
+        >>> print(result)
+        B: yet another input
+    """  # noqa
 
     _runnables: Iterable[Runnable[Input, Output]]
     """List of runnables to be branched."""
@@ -31,6 +78,7 @@ class RunnableRandomBranch(Runnable[Input, Output]):
         *runnables: Runnable[Input, Output] | Callable[[Input], Output],
         probs: Iterable[float] | None = None,
         generate_random_value: Callable[[], float] = random.random,
+        allowed_numerical_error: float = 1e-8,
     ):
         # defaults
         if probs is None:
@@ -41,7 +89,7 @@ class RunnableRandomBranch(Runnable[Input, Output]):
         if any(map(lambda x: x < 0, probs)):
             raise ValueError(f'Probabilities must be non-negative: probs={probs}')  # noqa
         # check the sum of probabilities
-        if abs(sum(probs) - 1.0) > self.__allowed_numerical_error:
+        if abs(sum(probs) - 1.0) > allowed_numerical_error:
             # NOTE: the difference is allowed to be within a small numerical error  # noqa
             raise ValueError(f'The sum of probabilities must be 1.0: sum={sum(probs)}')  # noqa
 
@@ -58,10 +106,36 @@ class RunnableRandomBranch(Runnable[Input, Output]):
         ]
         self._cum_probs = list(accumulate(probs, func=operator.add))
         self._generate_random_value = generate_random_value
+        self.__allowed_numerical_error = allowed_numerical_error
 
-    def invoke(self, *args, **kwargs) -> Output:
-        x = self._generate_random_value()
-        for runnable, thresh in zip(self._runnables, self._cum_probs):
-            if 0 <= x <= thresh:
-                return runnable.invoke(*args, **kwargs)
-        raise ValueError(f'The random number is out of range: random value={x}, cumprod={self._cum_probs}')  # noqa
+        super().__init__(
+            RunnableMap(
+                x=RunnablePassthrough(),
+                rv=RunnableLambda(lambda _: generate_random_value()),
+            ),
+            RunnableBranch(
+                *[
+                    (
+                        RunnablePick("rv")
+                        | RunnableLambda(partial(self._a_is_ge_0_le_b, b=thresh)),
+                        RunnablePick("x") | runnable,
+                    )
+                    for runnable, thresh in zip(self._runnables, self._cum_probs)
+                ],
+                (
+                    RunnablePick("rv")
+                    | RunnableLambda(
+                        lambda x: f'The random number x is out of range [0, 1]: {x=}'  # noqa
+                    )
+                    | RunnableLambda(self._raise_value_error)
+                )
+            ),
+        )
+
+    @staticmethod
+    def _a_is_ge_0_le_b(a: float, b: float) -> bool:
+        """Check if a is less than or equal to b."""
+        return 0 <= a <= b
+
+    def _raise_value_error(self, msg: str) -> None:
+        raise ValueError(msg)

--- a/runnable_family/runnable_diff.py
+++ b/runnable_family/runnable_diff.py
@@ -2,6 +2,7 @@ from langchain_core.runnables import (
     Runnable,
     RunnableLambda,
     RunnableParallel,
+    RunnableSequence,
 )
 from langchain_core.runnables.base import Input, Output
 from typing import Any, Iterable, TypeVar
@@ -9,11 +10,36 @@ from typing import Any, Iterable, TypeVar
 InterMediate = TypeVar("InterMediate", covariant=True)
 
 
-class RunnableDiff(Runnable[Input, Output]):
-    ''' A simple implementation of Chain To Compare Two Runnables
-    '''
+class RunnableDiff(RunnableSequence[Input, Output]):
+    """
+    A runnable that computes the difference between the outputs of two
+    runnables. It runs two runnables in parallel and then applies a
+    diff function to their outputs.
 
-    _diff_chain: Runnable[Input, Output]
+    Args:
+        runnable1: The first runnable to run.
+        runnable2: The second runnable to run.
+        diff: A runnable or callable that takes two outputs and computes
+            the difference between them. It should accept an iterable of
+            two intermediate outputs and return the final output.
+    Example:
+        >>> from runnable_family.runnable_diff import RunnableDiff
+        >>> from langchain_core.runnables import RunnableLambda, RunnableParallel
+        >>> def runnable1(x):
+        ...     return x + 1
+        >>> def runnable2(x):
+        ...     return x + 2
+        >>> def diff(outputs):
+        ...     return outputs[0] - outputs[1]
+        >>> diff_runnable = RunnableDiff(
+        ...    runnable1=RunnableLambda(runnable1),
+        ...    runnable2=RunnableLambda(runnable2),
+        ...    diff=RunnableLambda(diff)
+        ... )
+        >>> result = diff_runnable.invoke(10)
+        >>> print(result)
+        -1
+    """
 
     def __init__(
         self,
@@ -21,32 +47,12 @@ class RunnableDiff(Runnable[Input, Output]):
         runnable2: Runnable[Input, InterMediate],
         diff: Runnable[Iterable[InterMediate], Output],
     ):
-        self._diff_chain = (
+        super().__init__(
             RunnableParallel(**{
                 'output1': runnable1,
                 'output2': runnable2,
-            })  # type: ignore
-            | RunnableLambda(dict.values)
-            | RunnableLambda(list)
-            | diff
+            }),
+            RunnableLambda(dict.values),
+            RunnableLambda(list),
+            diff,
         )
-
-    def invoke(self, *args, **kwargs) -> Output:
-        # To make it a concrete class
-        return self._diff_chain.invoke(*args, **kwargs)
-
-    def __getattribute__(self, name: str) -> Any:
-        if name in ["_diff_chain", "invoke"]:
-            return super().__getattribute__(name)
-        try:
-            return getattr(self._diff_chain, name)
-        except AttributeError:
-            return super().__getattribute__(name)
-
-    @property
-    def InputType(self) -> type[Input]:
-        return self._diff_chain.InputType
-
-    @property
-    def OutputType(self) -> type[Output]:
-        return self._diff_chain.OutputType

--- a/runnable_family/runnable_diff.py
+++ b/runnable_family/runnable_diff.py
@@ -5,7 +5,7 @@ from langchain_core.runnables import (
     RunnableSequence,
 )
 from langchain_core.runnables.base import Input, Output
-from typing import Any, Iterable, TypeVar
+from typing import Iterable, TypeVar
 
 InterMediate = TypeVar("InterMediate", covariant=True)
 
@@ -39,7 +39,7 @@ class RunnableDiff(RunnableSequence[Input, Output]):
         >>> result = diff_runnable.invoke(10)
         >>> print(result)
         -1
-    """
+    """  # noqa
 
     def __init__(
         self,
@@ -48,7 +48,7 @@ class RunnableDiff(RunnableSequence[Input, Output]):
         diff: Runnable[Iterable[InterMediate], Output],
     ):
         super().__init__(
-            RunnableParallel(**{
+            RunnableParallel(**{  # type: ignore
                 'output1': runnable1,
                 'output2': runnable2,
             }),

--- a/runnable_family/self_consistent.py
+++ b/runnable_family/self_consistent.py
@@ -3,28 +3,52 @@ from langchain_core.runnables import (
     Runnable,
     RunnableLambda,
     RunnableParallel,
+    RunnableSequence,
 )
 from langchain_core.runnables.base import Input, Output
-from typing import Any, Callable, Iterable, TypeVar
+from typing import Callable, Iterable, TypeVar
 
 InterMediate = TypeVar("InterMediate", covariant=True)
 
 
-class RunnableSelfConsistent(Runnable[Input, Output]):
-    ''' A simple implementation of Self-Consistent Chain as described in the paper:
-
-    Ref. https://arxiv.org/pdf/2203.11171.pdf
+class RunnableSelfConsistent(RunnableSequence[Input, Output]):
+    """A runnable that implements the self-consistent approach to aggregate
+    the outputs of multiple runnables. It runs the runnables in parallel,
+    collects their outputs, and aggregates them using a specified aggregation
+    function or runnable. This is useful for scenarios where you want to
+    gather multiple outputs from different runnables and then combine them
+    into a single output, such as in self-consistent reasoning or ensemble
+    methods.
+    This runnable is inspired by the self-consistent approach in
+    "Self-Consistency Improves Chain of Thought Reasoning in Language Models"
+    (https://arxiv.org/abs/2203.11171).
 
     Args:
-        runnables: Iterable[Runnable[Input, InterMediate]]: A list of runnables
-        aggregate: Runnable[Iterable[InterMediate], Output] | Callable[[Iterable[InterMediate]], Output]:
-            A runnable or a callable to aggregate the output of the runnables.
-            Default is to count the most common output.
-            If there are the most common outputs, the first one is returned,
-            e.g. 1 is returned for the runnables' output [0, 1, 1, 2, 2].
-    '''  # noqa
+        runnables: An iterable of runnables to run in parallel.
+        aggregate: A runnable or callable that takes an iterable of
+            intermediate outputs and aggregates them into a final output.
+            If not provided, it defaults to counting the occurrences of each
+            output and returning the most common one.
 
-    _self_consistent_chain: Runnable[Input, Output]
+    Example:
+        >>> from langchain_core.runnables import RunnableLambda
+        >>> from runnable_family.self_consistent import RunnableSelfConsistent
+        >>> def runnable_a(x):
+        ...     return x + 1
+        >>> def runnable_b(x):
+        ...     return x + 2
+        >>> def runnable_c(x):
+        ...     return x + 1
+        >>> runnables = [
+        ...     RunnableLambda(runnable_a),
+        ...     RunnableLambda(runnable_b),
+        ...     RunnableLambda(runnable_c),
+        ... ]
+        >>> self_consistent_runnable = RunnableSelfConsistent(runnables)
+        >>> result = self_consistent_runnable.invoke(10)
+        >>> print(result)
+        11
+    """  # noqa
 
     def __init__(
         self,
@@ -37,29 +61,10 @@ class RunnableSelfConsistent(Runnable[Input, Output]):
     ):
         if callable(aggregate):
             aggregate = RunnableLambda(aggregate)
-        self._self_consistent_chain = (
-            RunnableParallel(**{str(i): runnable for i, runnable in enumerate(runnables)})  # type: ignore # noqa
-            | RunnableLambda(dict.values)
-            | RunnableLambda(list)
-            | aggregate
+
+        super().__init__(
+            RunnableParallel(**{str(i): runnable for i, runnable in enumerate(runnables)}),  # type: ignore # noqa
+            RunnableLambda(dict.values),
+            RunnableLambda(list),
+            aggregate,
         )
-
-    def invoke(self, *args, **kwargs) -> Output:
-        # To make it a concrete class
-        return self._self_consistent_chain.invoke(*args, **kwargs)
-
-    def __getattribute__(self, name: str) -> Any:
-        if name in ["_self_consistent_chain", "invoke"]:
-            return super().__getattribute__(name)
-        try:
-            return getattr(self._self_consistent_chain, name)
-        except AttributeError:
-            return super().__getattribute__(name)
-
-    @property
-    def InputType(self) -> type[Input]:
-        return self._self_consistent_chain.InputType
-
-    @property
-    def OutputType(self) -> type[Output]:
-        return self._self_consistent_chain.OutputType

--- a/runnable_family/self_refine.py
+++ b/runnable_family/self_refine.py
@@ -6,7 +6,7 @@ from langchain_core.runnables import (
     RunnableSequence,
 )
 from langchain_core.runnables.base import Input, Output
-from typing import Any, TypeVar
+from typing import TypeVar
 
 InterMediate = TypeVar("InterMediate", covariant=True)
 InterMediate2 = TypeVar("InterMediate2", covariant=True)
@@ -52,7 +52,7 @@ class RunnableSelfRefine(RunnableSequence[Input, Output]):
         >>> result = self_refine_runnable.invoke("test")
         >>> print(result)
         refined: 'test' 'test initial' with FB 'feedback: test -> test initial'
-    """
+    """  # noqa
 
     _self_refine_chain: Runnable[Input, Output]
 

--- a/runnable_family/self_translate.py
+++ b/runnable_family/self_translate.py
@@ -1,6 +1,7 @@
 from langchain_core.runnables import (
     Runnable,
-    RunnablePassthrough
+    RunnablePassthrough,
+    RunnableSequence,
 )
 from langchain_core.runnables.base import Input, Output
 from typing import Generic, TypeVar
@@ -10,17 +11,60 @@ InterMediateOutput = TypeVar("InterMediateOutput", covariant=True)
 
 
 class RunnableSelfTranslate(
-    Runnable[Input, Output],
+    RunnableSequence[Input, Output],
     Generic[Input, Output, InterMediateInput, InterMediateOutput],
 ):
-    '''A simple implementation of Self-Translate Chain as described in the paper:
+    """A runnable that implements the Self-Translate Chain methodology.
+
+    This runnable is designed to translate an input into an intermediate
+    representation, process it, and then translate it back to the final output.
 
     Ref. https://arxiv.org/abs/2308.01223
-    '''  # noqa
+
+    Args:
+        translater: A runnable that translates the input into an intermediate
+            representation.
+        inverse_translater: A runnable that translates the intermediate
+            representation back to the final output.
+        runnable: An optional runnable that processes the intermediate
+            representation. If not provided, it defaults to a passthrough
+            runnable that simply returns the intermediate input as output.
+    Example:
+        >>> from langchain_core.runnables import RunnableLambda
+        >>> from runnable_family.self_translate import RunnableSelfTranslate
+        >>> def translater(input):
+        ...     return input + " translated"
+        >>> def inverse_translater(intermediate):
+        ...     return intermediate + " final output"
+        >>> def runnable(intermediate):
+        ...     return intermediate.upper()
+        >>> # Usage 1
+        >>> self_translate_runnable = RunnableSelfTranslate(
+        ...     translater=RunnableLambda(translater),
+        ...     inverse_translater=RunnableLambda(inverse_translater),
+        ...     runnable=RunnableLambda(runnable),
+        ... )
+        >>> result = self_translate_runnable.invoke("test input")
+        >>> print(result)
+        TEST INPUT TRANSLATED final output
+        >>> # Usage 2
+        >>> translate_runnable_factory = RunnableSelfTranslate(
+        ...     translater=RunnableLambda(translater),
+        ...     inverse_translater=RunnableLambda(inverse_translater),
+        ... )
+        >>> self_translate_runnable2 = translate_runnable_factory.with_runnable(
+        ...    RunnableLambda(runnable)
+        ... )
+        >>> result2 = self_translate_runnable2.invoke("another test input")
+        >>> print(result2)
+        ANOTHER TEST INPUT TRANSLATED final output
+        >>> _for_reference = translate_runnable_factory.invoke("test input")
+        >>> print(_for_reference)
+        test input translated final output
+    """
 
     _translater: Runnable[Input, InterMediateInput]
     _inverse_translater: Runnable[InterMediateOutput, Output]
-    _runnable: Runnable[InterMediateInput, InterMediateOutput]
 
     def __init__(
         self,
@@ -28,32 +72,20 @@ class RunnableSelfTranslate(
         inverse_translater: Runnable[InterMediateOutput, Output],
         runnable: Runnable[InterMediateInput, InterMediateOutput] | None = None,  # noqa
     ):
-        self._runnable = runnable or RunnablePassthrough()    # type: ignore
+        super().__init__(
+            translater,
+            runnable or RunnablePassthrough(),  # type: ignore
+            inverse_translater,
+        )
         self._translater = translater
         self._inverse_translater = inverse_translater
-
-    def invoke(self, input: Input, *args, **kwargs) -> Output:
-        # To make it a concrete class
-        return (
-            self._translater
-            | self._runnable
-            | self._inverse_translater
-        ).invoke(input, *args, **kwargs)
 
     def with_runnable(
         self,
         runnable: Runnable[InterMediateInput, InterMediateOutput],
-    ) -> Runnable[Input, Output]:
+    ) -> "RunnableSelfTranslate[Input, Output, InterMediateInput, InterMediateOutput]":
         return RunnableSelfTranslate(
             self._translater,
             self._inverse_translater,
             runnable,
         )
-
-    @property
-    def InputType(self) -> type[Input]:
-        return self._translater.InputType
-
-    @property
-    def OutputType(self) -> type[Output]:
-        return self._inverse_translater.OutputType

--- a/runnable_family/self_translate.py
+++ b/runnable_family/self_translate.py
@@ -61,7 +61,7 @@ class RunnableSelfTranslate(
         >>> _for_reference = translate_runnable_factory.invoke("test input")
         >>> print(_for_reference)
         test input translated final output
-    """
+    """  # noqa
 
     _translater: Runnable[Input, InterMediateInput]
     _inverse_translater: Runnable[InterMediateOutput, Output]
@@ -83,7 +83,7 @@ class RunnableSelfTranslate(
     def with_runnable(
         self,
         runnable: Runnable[InterMediateInput, InterMediateOutput],
-    ) -> "RunnableSelfTranslate[Input, Output, InterMediateInput, InterMediateOutput]":
+    ) -> "RunnableSelfTranslate[Input, Output, InterMediateInput, InterMediateOutput]":  # noqa
         return RunnableSelfTranslate(
             self._translater,
             self._inverse_translater,

--- a/runnable_family/self_translate.py
+++ b/runnable_family/self_translate.py
@@ -6,13 +6,13 @@ from langchain_core.runnables import (
 from langchain_core.runnables.base import Input, Output
 from typing import Generic, TypeVar
 
-InterMediateInput = TypeVar("InterMediateInput", contravariant=True)
-InterMediateOutput = TypeVar("InterMediateOutput", covariant=True)
+IntermediateInput = TypeVar("IntermediateInput", contravariant=True)
+IntermediateOutput = TypeVar("IntermediateOutput", covariant=True)
 
 
 class RunnableSelfTranslate(
     RunnableSequence[Input, Output],
-    Generic[Input, Output, InterMediateInput, InterMediateOutput],
+    Generic[Input, Output, IntermediateInput, IntermediateOutput],
 ):
     """A runnable that implements the Self-Translate Chain methodology.
 
@@ -63,14 +63,14 @@ class RunnableSelfTranslate(
         test input translated final output
     """  # noqa
 
-    _translater: Runnable[Input, InterMediateInput]
-    _inverse_translater: Runnable[InterMediateOutput, Output]
+    _translater: Runnable[Input, IntermediateInput]
+    _inverse_translater: Runnable[IntermediateOutput, Output]
 
     def __init__(
         self,
-        translater: Runnable[Input, InterMediateInput],
-        inverse_translater: Runnable[InterMediateOutput, Output],
-        runnable: Runnable[InterMediateInput, InterMediateOutput] | None = None,  # noqa
+        translater: Runnable[Input, IntermediateInput],
+        inverse_translater: Runnable[IntermediateOutput, Output],
+        runnable: Runnable[IntermediateInput, IntermediateOutput] | None = None,  # noqa
     ):
         super().__init__(
             translater,
@@ -82,8 +82,8 @@ class RunnableSelfTranslate(
 
     def with_runnable(
         self,
-        runnable: Runnable[InterMediateInput, InterMediateOutput],
-    ) -> "RunnableSelfTranslate[Input, Output, InterMediateInput, InterMediateOutput]":  # noqa
+        runnable: Runnable[IntermediateInput, IntermediateOutput],
+    ) -> "RunnableSelfTranslate[Input, Output, IntermediateInput, IntermediateOutput]":  # noqa
         return RunnableSelfTranslate(
             self._translater,
             self._inverse_translater,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -23,23 +23,23 @@ def test_runnable_constant(
 
 
 @pytest.mark.parametrize(
-    'a, b, left, expected',
+    'x, constant, prepend, expected',
     [
-        (1, 2, True, 3),
-        (2, 3, False, 5),
-        ('a', 'b', True, 'ab'),
-        ('b', 'c', False, 'cb'),
+        (1, 2, True, 2 + 1),
+        (2, 3, False, 2 + 3),
+        ('a', 'b', True, 'b' + 'a'),
+        ('b', 'c', False, 'b' + 'c'),
     ]
 )
 def test_runnable_add(
-    a: str | int,
-    b: str | int,
-    left: bool,
+    x: str | int,
+    constant: str | int,
+    prepend: bool,
     expected: str | int,
 ):
-    assert type(a) is type(b)
-    add_b: RunnableAdd = RunnableAdd(b, left=left)
-    assert add_b.invoke(a) == expected
+    assert type(x) is type(constant)
+    add_b: RunnableAdd = RunnableAdd(constant, prepend=prepend)
+    assert add_b.invoke(x) == expected
 
 
 def test_runnable_add_with_non_addable():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,10 +1,7 @@
 import pytest
-from typing import Callable
 from runnable_family.basic import (
     RunnableAdd,
     RunnableConstant,
-    RunnableLog,
-    RunnablePartialLambda,
 )
 
 
@@ -48,43 +45,3 @@ def test_runnable_add(
 def test_runnable_add_with_non_addable():
     with pytest.raises(TypeError):
         RunnableAdd({'a': 1}).invoke({'a': 1})
-
-
-@pytest.mark.parametrize(
-    'input_obj, func, kwargs, expected',
-    [
-        (0, lambda x: x+10, {}, 10),
-        ('x', lambda x, a: x + a, {'a': 'A'}, 'xA'),
-        ('z', lambda x, a: x + a, {'a': 'A'}, 'zA'),
-        ('x', lambda x, a, b: x + a + b, {'a': 'A', 'b': 'B'}, 'xAB'),
-    ]
-)
-def test_runnable_partial_lambda(
-    input_obj: str | int,
-    func: Callable[[str | int], str | int],
-    kwargs: dict[str, str | int],
-    expected: str | int,
-    mocker,
-) -> None:
-    mock_func = mocker.MagicMock(side_effect=func)
-    partial_lambda = RunnablePartialLambda(mock_func, **kwargs)
-    assert partial_lambda.invoke(input_obj) == expected
-    mock_func.assert_called_once_with(input_obj, **kwargs)
-
-
-@pytest.mark.parametrize(
-    'input_obj',
-    [
-        0,
-        'a',
-        {'a': 1},
-    ]
-)
-def test_runnable_log(
-    input_obj,
-    mocker,
-):
-    func = mocker.MagicMock(return_value=None)
-    log_runnable = RunnableLog(func)
-    log_runnable.invoke(input_obj)
-    func.assert_called_once_with(input_obj)

--- a/tests/test_lambda_family.py
+++ b/tests/test_lambda_family.py
@@ -1,0 +1,90 @@
+import pytest
+from typing import Callable
+from runnable_family.basic import (
+    RunnableAdd,
+    RunnableConstant,
+    RunnableLog,
+    RunnablePartialLambda,
+)
+
+
+@pytest.mark.parametrize(
+    'input_obj, expected',
+    [
+        (0, 0),
+        ('a', 0),
+        ({'a': 1}, 0),
+        ({'a': 1}, 1),
+    ]
+)
+def test_runnable_constant(
+    input_obj,
+    expected,
+):
+    constant = RunnableConstant(expected)
+    assert constant.invoke(input_obj) == expected
+
+
+@pytest.mark.parametrize(
+    'a, b, left, expected',
+    [
+        (1, 2, True, 3),
+        (2, 3, False, 5),
+        ('a', 'b', True, 'ab'),
+        ('b', 'c', False, 'cb'),
+    ]
+)
+def test_runnable_add(
+    a: str | int,
+    b: str | int,
+    left: bool,
+    expected: str | int,
+):
+    assert type(a) is type(b)
+    add_b: RunnableAdd = RunnableAdd(b, left=left)
+    assert add_b.invoke(a) == expected
+
+
+def test_runnable_add_with_non_addable():
+    with pytest.raises(TypeError):
+        RunnableAdd({'a': 1}).invoke({'a': 1})
+
+
+@pytest.mark.parametrize(
+    'input_obj, func, kwargs, expected',
+    [
+        (0, lambda x: x+10, {}, 10),
+        ('x', lambda x, a: x + a, {'a': 'A'}, 'xA'),
+        ('z', lambda x, a: x + a, {'a': 'A'}, 'zA'),
+        ('x', lambda x, a, b: x + a + b, {'a': 'A', 'b': 'B'}, 'xAB'),
+    ]
+)
+def test_runnable_partial_lambda(
+    input_obj: str | int,
+    func: Callable[[str | int], str | int],
+    kwargs: dict[str, str | int],
+    expected: str | int,
+    mocker,
+) -> None:
+    mock_func = mocker.MagicMock(side_effect=func)
+    partial_lambda = RunnablePartialLambda(mock_func, **kwargs)
+    assert partial_lambda.invoke(input_obj) == expected
+    mock_func.assert_called_once_with(input_obj, **kwargs)
+
+
+@pytest.mark.parametrize(
+    'input_obj',
+    [
+        0,
+        'a',
+        {'a': 1},
+    ]
+)
+def test_runnable_log(
+    input_obj,
+    mocker,
+):
+    func = mocker.MagicMock(return_value=None)
+    log_runnable = RunnableLog(func)
+    log_runnable.invoke(input_obj)
+    func.assert_called_once_with(input_obj)

--- a/tests/test_lambda_family.py
+++ b/tests/test_lambda_family.py
@@ -1,53 +1,8 @@
 import pytest
 from typing import Callable
-from runnable_family.basic import (
-    RunnableAdd,
-    RunnableConstant,
-    RunnableLog,
+from runnable_family.lambda_family import (
     RunnablePartialLambda,
 )
-
-
-@pytest.mark.parametrize(
-    'input_obj, expected',
-    [
-        (0, 0),
-        ('a', 0),
-        ({'a': 1}, 0),
-        ({'a': 1}, 1),
-    ]
-)
-def test_runnable_constant(
-    input_obj,
-    expected,
-):
-    constant = RunnableConstant(expected)
-    assert constant.invoke(input_obj) == expected
-
-
-@pytest.mark.parametrize(
-    'a, b, left, expected',
-    [
-        (1, 2, True, 3),
-        (2, 3, False, 5),
-        ('a', 'b', True, 'ab'),
-        ('b', 'c', False, 'cb'),
-    ]
-)
-def test_runnable_add(
-    a: str | int,
-    b: str | int,
-    left: bool,
-    expected: str | int,
-):
-    assert type(a) is type(b)
-    add_b: RunnableAdd = RunnableAdd(b, left=left)
-    assert add_b.invoke(a) == expected
-
-
-def test_runnable_add_with_non_addable():
-    with pytest.raises(TypeError):
-        RunnableAdd({'a': 1}).invoke({'a': 1})
 
 
 @pytest.mark.parametrize(
@@ -70,21 +25,3 @@ def test_runnable_partial_lambda(
     partial_lambda = RunnablePartialLambda(mock_func, **kwargs)
     assert partial_lambda.invoke(input_obj) == expected
     mock_func.assert_called_once_with(input_obj, **kwargs)
-
-
-@pytest.mark.parametrize(
-    'input_obj',
-    [
-        0,
-        'a',
-        {'a': 1},
-    ]
-)
-def test_runnable_log(
-    input_obj,
-    mocker,
-):
-    func = mocker.MagicMock(return_value=None)
-    log_runnable = RunnableLog(func)
-    log_runnable.invoke(input_obj)
-    func.assert_called_once_with(input_obj)

--- a/tests/test_print_family.py
+++ b/tests/test_print_family.py
@@ -1,0 +1,90 @@
+import pytest
+from typing import Callable
+from runnable_family.basic import (
+    RunnableAdd,
+    RunnableConstant,
+    RunnableLog,
+    RunnablePartialLambda,
+)
+
+
+@pytest.mark.parametrize(
+    'input_obj, expected',
+    [
+        (0, 0),
+        ('a', 0),
+        ({'a': 1}, 0),
+        ({'a': 1}, 1),
+    ]
+)
+def test_runnable_constant(
+    input_obj,
+    expected,
+):
+    constant = RunnableConstant(expected)
+    assert constant.invoke(input_obj) == expected
+
+
+@pytest.mark.parametrize(
+    'a, b, left, expected',
+    [
+        (1, 2, True, 3),
+        (2, 3, False, 5),
+        ('a', 'b', True, 'ab'),
+        ('b', 'c', False, 'cb'),
+    ]
+)
+def test_runnable_add(
+    a: str | int,
+    b: str | int,
+    left: bool,
+    expected: str | int,
+):
+    assert type(a) is type(b)
+    add_b: RunnableAdd = RunnableAdd(b, left=left)
+    assert add_b.invoke(a) == expected
+
+
+def test_runnable_add_with_non_addable():
+    with pytest.raises(TypeError):
+        RunnableAdd({'a': 1}).invoke({'a': 1})
+
+
+@pytest.mark.parametrize(
+    'input_obj, func, kwargs, expected',
+    [
+        (0, lambda x: x+10, {}, 10),
+        ('x', lambda x, a: x + a, {'a': 'A'}, 'xA'),
+        ('z', lambda x, a: x + a, {'a': 'A'}, 'zA'),
+        ('x', lambda x, a, b: x + a + b, {'a': 'A', 'b': 'B'}, 'xAB'),
+    ]
+)
+def test_runnable_partial_lambda(
+    input_obj: str | int,
+    func: Callable[[str | int], str | int],
+    kwargs: dict[str, str | int],
+    expected: str | int,
+    mocker,
+) -> None:
+    mock_func = mocker.MagicMock(side_effect=func)
+    partial_lambda = RunnablePartialLambda(mock_func, **kwargs)
+    assert partial_lambda.invoke(input_obj) == expected
+    mock_func.assert_called_once_with(input_obj, **kwargs)
+
+
+@pytest.mark.parametrize(
+    'input_obj',
+    [
+        0,
+        'a',
+        {'a': 1},
+    ]
+)
+def test_runnable_log(
+    input_obj,
+    mocker,
+):
+    func = mocker.MagicMock(return_value=None)
+    log_runnable = RunnableLog(func)
+    log_runnable.invoke(input_obj)
+    func.assert_called_once_with(input_obj)

--- a/tests/test_print_family.py
+++ b/tests/test_print_family.py
@@ -1,75 +1,7 @@
 import pytest
-from typing import Callable
-from runnable_family.basic import (
-    RunnableAdd,
-    RunnableConstant,
+from runnable_family.print_family import (
     RunnableLog,
-    RunnablePartialLambda,
 )
-
-
-@pytest.mark.parametrize(
-    'input_obj, expected',
-    [
-        (0, 0),
-        ('a', 0),
-        ({'a': 1}, 0),
-        ({'a': 1}, 1),
-    ]
-)
-def test_runnable_constant(
-    input_obj,
-    expected,
-):
-    constant = RunnableConstant(expected)
-    assert constant.invoke(input_obj) == expected
-
-
-@pytest.mark.parametrize(
-    'a, b, left, expected',
-    [
-        (1, 2, True, 3),
-        (2, 3, False, 5),
-        ('a', 'b', True, 'ab'),
-        ('b', 'c', False, 'cb'),
-    ]
-)
-def test_runnable_add(
-    a: str | int,
-    b: str | int,
-    left: bool,
-    expected: str | int,
-):
-    assert type(a) is type(b)
-    add_b: RunnableAdd = RunnableAdd(b, left=left)
-    assert add_b.invoke(a) == expected
-
-
-def test_runnable_add_with_non_addable():
-    with pytest.raises(TypeError):
-        RunnableAdd({'a': 1}).invoke({'a': 1})
-
-
-@pytest.mark.parametrize(
-    'input_obj, func, kwargs, expected',
-    [
-        (0, lambda x: x+10, {}, 10),
-        ('x', lambda x, a: x + a, {'a': 'A'}, 'xA'),
-        ('z', lambda x, a: x + a, {'a': 'A'}, 'zA'),
-        ('x', lambda x, a, b: x + a + b, {'a': 'A', 'b': 'B'}, 'xAB'),
-    ]
-)
-def test_runnable_partial_lambda(
-    input_obj: str | int,
-    func: Callable[[str | int], str | int],
-    kwargs: dict[str, str | int],
-    expected: str | int,
-    mocker,
-) -> None:
-    mock_func = mocker.MagicMock(side_effect=func)
-    partial_lambda = RunnablePartialLambda(mock_func, **kwargs)
-    assert partial_lambda.invoke(input_obj) == expected
-    mock_func.assert_called_once_with(input_obj, **kwargs)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Enhance the organization and documentation of the runnable_family modules by removing unused classes, improving docstrings, and updating dependencies. Add tests for new functionality and ensure compatibility with the latest versions of langchain and langgraph.