### PR TITLE
Fix graph imports and update dependencies for RunnableLoopback class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "runnable_family"
 description = "A python library implementing a family of Runnables in langchain"
 dynamic = ["version"]
 readme = "README.md"
-dependencies = ["grandalf >= 0.8", "langchain >= 0.3.0", "langgraph>=0.4.0"]
+dependencies = ["grandalf >= 0.8", "langchain >= 0.3.0", "langgraph>=0.5.0"]
 requires-python = ">=3.10"
 authors = [{ name = "hmasdev" }]
 maintainers = [{ name = "hmasdev" }]

--- a/runnable_family/loopback.py
+++ b/runnable_family/loopback.py
@@ -135,7 +135,7 @@ class RunnableLoopback(Runnable[Input, Output]):
         self._graph = graph.compile()
 
     def invoke(self, input: Input, *args, **kwargs) -> Output:
-        input_ = self._InternalStateSchema(input=input)  # type: ignore
+        input_ = dict(input=input)  # type: ignore
         output_ = self._graph.invoke(input_, *args, **kwargs)  # type: ignore
         return cast(Output, output_["output"])
 

--- a/runnable_family/loopback.py
+++ b/runnable_family/loopback.py
@@ -9,7 +9,8 @@ from langchain_core.runnables import (
 )
 from langchain_core.runnables.base import Input, Output
 import langchain_core.runnables.graph
-from langgraph.graph.graph import Graph, CompiledGraph, END
+from langgraph.graph import StateGraph, END
+from langgraph.graph.state import CompiledStateGraph
 from typing import Callable
 from uuid import uuid4
 from .operator import RunnableAddConstant
@@ -38,7 +39,7 @@ class RunnableLoopback(Runnable[Input, Output]):
             for the next iteration.
 
     Attributes:
-        _graph (CompiledGraph): Compiled graph of the runnable.
+        _graph (CompiledStateGraph): Compiled graph of the runnable.
         _runnable (Runnable[Input, Output]): The main runnable to be looped back.
         _condition (Runnable[Output, bool]): Condition to determine if looping continues.
         _loopback (Runnable[Output, Input]): Runnable to transform output back to input.
@@ -63,7 +64,7 @@ class RunnableLoopback(Runnable[Input, Output]):
         >>> # 0 -(my_runnable)-> 1 -(my_loopback)-> 2 -(my_runnable)-> 3 -(my_loopback)-> 6 -(my_runnable)-> 7
     """  # noqa
 
-    _graph: CompiledGraph
+    _graph: CompiledStateGraph
     '''Compiled graph of the runnable.'''
 
     _runnable: Runnable[Input, Output]
@@ -88,7 +89,7 @@ class RunnableLoopback(Runnable[Input, Output]):
         self._loopback = loopback
 
         # create graph
-        graph = Graph()
+        graph = StateGraph(Input)
         graph.add_node('runnable', runnable)
         graph.add_node('loopback', loopback)
         graph.add_conditional_edges(

--- a/runnable_family/loopback.py
+++ b/runnable_family/loopback.py
@@ -1,5 +1,5 @@
 from operator import itemgetter
-from typing import Callable, Generic, TypedDict, cast
+from typing import Callable, TypedDict, cast
 from uuid import uuid4
 
 import langchain


### PR DESCRIPTION
Update imports and types in the RunnableLoopback class to align with the latest langgraph library changes. Adjust the langgraph dependency version in pyproject.toml and add a job to run unit tests with minimum dependency versions.